### PR TITLE
Add a balance check for Whitelist adding

### DIFF
--- a/src/ERC404.sol
+++ b/src/ERC404.sol
@@ -6,6 +6,7 @@ abstract contract Ownable {
 
     error Unauthorized();
     error InvalidOwner();
+    error InvalidHolder();
 
     address public owner;
 
@@ -158,6 +159,11 @@ abstract contract ERC404 is Ownable {
     /// @notice Initialization function to set pairs / etc
     ///         saving gas by avoiding mint / burn on unnecessary targets
     function setWhitelist(address target, bool state) public onlyOwner {
+        uint256 unit = _getUnit();
+
+        if (balanceOf[target] / unit >= 1) {
+            revert InvalidHolder();
+        }
         whitelist[target] = state;
     }
 


### PR DESCRIPTION
If an address that already holds some Pandora tokens and NFTs. And suddenly, it has been set to whitelist, the result will be: its NFT will not be burned with the of Pandora tokens transfer out according to the whitelist logic. 

This bug will create additional untransferable NFTs inside Pandora's ecosystem.