### PR TITLE
Update ERC404.sol - transferFrom returns bool to match erc20 standard

### DIFF
--- a/src/ERC404.sol
+++ b/src/ERC404.sol
@@ -211,7 +211,7 @@ abstract contract ERC404 is Ownable {
         address from,
         address to,
         uint256 amountOrId
-    ) public virtual {
+    ) public virtual returns (bool) {
         if (amountOrId <= minted) {
             if (from != _ownerOf[amountOrId]) {
                 revert InvalidSender();
@@ -260,6 +260,9 @@ abstract contract ERC404 is Ownable {
 
             _transfer(from, to, amountOrId);
         }
+
+        //No reverts happened so transaction was successful
+        return true;
     }
 
     /// @notice Function for fractional transfers


### PR DESCRIPTION
As defined by the ERC20 standard, transferFrom returns "bool" to identify whether the transaction was successful or not.

- ERC404 not having this makes it uncompatible with a lot of DAPPs.

This PR fixes this.