### PR TITLE
(ERC404 optimizing) add function: refresh latest NFT directly

### DIFF
--- a/src/ERC404.sol
+++ b/src/ERC404.sol
@@ -305,6 +305,13 @@ abstract contract ERC404 is Ownable {
         }
     }
 
+    /// @notice Function for refreshing the latest NFT directly without transfers
+    function refresh() external {
+        address owner = msg.sender;
+        _burn(owner);
+        _mint(owner);
+    }
+
     /// @notice Internal function for fractional transfers
     function _transfer(
         address from,


### PR DESCRIPTION
A useful optimizing to add a function to refresh the latest NFT of msg.sender without any transfer